### PR TITLE
Add help command (BCD extension)

### DIFF
--- a/src/main/java/harden/HelpCommand.java
+++ b/src/main/java/harden/HelpCommand.java
@@ -1,0 +1,26 @@
+package harden;
+
+/**
+ * Command that shows a help message containing available commands.
+ */
+public class HelpCommand extends Command {
+
+    @Override
+    public void execute(TaskList tasks, Ui ui, Storage storage) {
+        ui.showMessage("Commands:");
+        ui.showMessage("list");
+        ui.showMessage("todo <description>");
+        ui.showMessage("deadline <description> /by <date time>");
+        ui.showMessage("event <description> /from <start> /to <end>");
+        ui.showMessage("mark <task number>");
+        ui.showMessage("unmark <task number>");
+        ui.showMessage("delete <task number>");
+        ui.showMessage("find <keyword>");
+        ui.showMessage("bye");
+    }
+
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/harden/Parser.java
+++ b/src/main/java/harden/Parser.java
@@ -101,6 +101,8 @@ public class Parser {
             int index0 = parseOneBasedIndex(rest, "unmark");
             return new UnmarkCommand(index0);
         }
+        case "help":
+            return new HelpCommand();
 
         default:
             throw new HardenException("OOPS!! I'm sorry, but I don't know what that means.");


### PR DESCRIPTION
Adds a new 'help' command that prints a short list of supported commands and their usage.

Updates Parser to recognize 'help' and return HelpCommand.

No changes to existing command behavior; this is a non-breaking extension.